### PR TITLE
update the URL for the OpenManus project as the project has being moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A curated list of awesome open-source projects built on or inspired by [browser-
 
 These projects leverage `browser-use` or similar browser automation techniques as part of a larger AI agent system designed for general task completion or analysis.
 
-*   [OpenManus](https://github.com/mannaandpoem/OpenManus) - An open-source multi-agent system inspired by Manus, designed to accomplish complex tasks using tools and browser interaction. 
+*   [OpenManus](https://github.com/FoundationAgents/OpenManus) - An open-source multi-agent system inspired by Manus, designed to accomplish complex tasks using tools and browser interaction. 
 *   [Agent-tars](https://github.com/bytedance/UI-TARS-desktop/tree/main/apps/agent-tars) - A multimodal AI agent that visually interprets web pages to perform browser operations and integrates with system commands. 
 *   [nanobrowser](https://github.com/nanobrowser/nanobrowser) - A multi-agent system running locally in the browser for real-time analysis, featuring self-correction and dynamic navigation instructions. 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the OpenManus link in the README to point to the new GitHub repository (FoundationAgents/OpenManus) after the project moved. Prevents a broken link and keeps the catalog accurate.

<sup>Written for commit 2aabbeaffd5ed1662f0a3b344af48455e01bc87a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

