### PR TITLE
Add BrowserTrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@ Projects applying `browser-use` principles to solve problems in a specific domai
 Projects focused on simplifying the use of `browser-use` by providing wrappers, APIs, or extensions.
 
 *   [A5-Browser-Use](https://github.com/AgenticA5/A5-Browser-Use/) - An all-in-one solution integrating `browser-use` with a user-friendly RESTful API and Chrome extension for simplified agentic browser automation. 
+*   [BrowserTrace](https://github.com/aaronlab/browsertrace) - A local-first trace viewer for failed Browser Use runs, with screenshots, URLs, actions, model I/O, status, errors, and public-safe HTML exports.
 
 *Contributions welcome! Feel free to open an issue or pull request to add more projects.*


### PR DESCRIPTION
## Summary

Add BrowserTrace to the Integrations & Ease of Use section.

BrowserTrace is a local-first trace viewer for failed Browser Use runs. It records screenshots, URLs, actions, model input/output, status, and errors, then can export a public-safe standalone HTML report for issue threads or bug reports.

## Verification

- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add BrowserTrace to the README’s Integrations & Ease of Use section to help users debug failed `browser-use` runs. It captures screenshots, URLs, actions, model I/O, status, and errors, and supports public-safe HTML exports.

<sup>Written for commit 094a756e7d64e3f3a209dba539a4d4e01dc6ddaf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

